### PR TITLE
Rename path() logging paramter to key()

### DIFF
--- a/monologue/src/main/java/monologue/Annotations.java
+++ b/monologue/src/main/java/monologue/Annotations.java
@@ -11,8 +11,8 @@ public class Annotations {
   /**
    * Logs the annotated field/method to WPILOG if inside a {@link Logged} class.
    * 
-   * @param path  [optional] the relative path to log to. If empty, the path will
-   *             be the name of the field/method
+   * @param key   [optional] the key to log the variable as. If empty, the key
+   *              will be the name of the field/method
    * @param level [optional] the log level to use
    */
   @Documented
@@ -20,12 +20,14 @@ public class Annotations {
   @Target({ ElementType.FIELD, ElementType.METHOD })
   public @interface LogFile {
     /**
-     * The relative path to log to. If empty, the path will be the name of the field/method.
+     * The key to log the variable as. If empty, the key will be the name of the
+     * field/method.
      */
-    public String path() default "";
+    public String key() default "";
 
     /**
      * The log level to use.
+     * 
      * @apiNote WPILIB Senders do not obey these levels as of now
      */
     public LogLevel level() default LogLevel.DEFAULT;
@@ -35,8 +37,8 @@ public class Annotations {
    * Logs the annotated field/method to NetworkTables if inside a {@link Logged}
    * class.
    * 
-   * @param path  [optional] the relative path to log to. If empty, the path will
-   *             be the name of the field/method
+   * @param key   [optional] the key to log the variable as in network talbes. If
+   *              empty, the key will be the name of the field/method
    * @param level [optional] the log level to use
    */
   @Documented
@@ -44,12 +46,14 @@ public class Annotations {
   @Target({ ElementType.FIELD, ElementType.METHOD })
   public @interface LogNT {
     /**
-     * The relative path to log to. If empty, the path will be the name of the field/method.
+     * The key to log the variable as. If empty, the key will be the name of the
+     * field/method.
      */
-    public String path() default "";
+    public String key() default "";
 
     /**
      * The log level to use.
+     * 
      * @apiNote WPILIB Senders do not obey these levels as of now
      */
     public LogLevel level() default LogLevel.DEFAULT;
@@ -58,43 +62,48 @@ public class Annotations {
   /**
    * Logs the annotated field/method to WPILOG if inside a {@link Logged} class.
    * 
-   * @param path  [optional] the relative path to log to. If empty, the path will
-   *             be the name of the field/method
+   * @param key [optional] the key to log the variable as. If empty, the key will
+   *            be the name of the field/method
    */
   @Documented
   @Retention(RetentionPolicy.RUNTIME)
   @Target({ ElementType.FIELD, ElementType.METHOD })
   public @interface LogOnceFile {
     /**
-     * The relative path to log to. If empty, the path will be the name of the field/method.
+     * The key to log the variable as. If empty, the key will be the name of the
+     * field/method.
      */
-    public String path() default "";
+    public String key() default "";
   }
 
   /**
    * Logs the annotated field/method to NetworkTables if inside a {@link Logged}
    * class.
    * 
-   * @param path  [optional] the relative path to log to. If empty, the path will
-   *             be the name of the field/method
+   * @param key [optional] the key to log the varialbe as. If empty, the key will
+   *            be the name of the field/method
    */
   @Documented
   @Retention(RetentionPolicy.RUNTIME)
   @Target({ ElementType.FIELD, ElementType.METHOD })
   public @interface LogOnceNT {
     /**
-     * The relative path to log to. If empty, the path will be the name of the field/method.
+     * The key to log the variable as. If empty, the key will be the name of the
+     * field/method.
      */
-    public String path() default "";
+    public String key() default "";
   }
 
   /**
-   * Makes the annotated field containing a {@link Logged} class not be recursed into.
+   * Makes the annotated field containing a {@link Logged} class not be recursed
+   * into.
    * 
-   * @apiNote this will also make fields inside the object in the field not be logged
+   * @apiNote this will also make fields inside the object in the field not be
+   *          logged
    */
   @Documented
   @Retention(RetentionPolicy.RUNTIME)
   @Target({ ElementType.FIELD })
-  public @interface IgnoreLogged {}
+  public @interface IgnoreLogged {
+  }
 }

--- a/monologue/src/main/java/monologue/EvalAnno.java
+++ b/monologue/src/main/java/monologue/EvalAnno.java
@@ -37,16 +37,16 @@ class EvalAnno {
         public static LogMetadata from(AccessibleObject element) {
             if (element.isAnnotationPresent(LogFile.class)) {
                 LogFile anno = element.getAnnotation(LogFile.class);
-                return new LogMetadata(anno.level(), false, anno.path());
+                return new LogMetadata(anno.level(), false, anno.key());
             } else if (element.isAnnotationPresent(LogNT.class)) {
                 LogNT anno = element.getAnnotation(LogNT.class);
-                return new LogMetadata(anno.level(), false, anno.path());
+                return new LogMetadata(anno.level(), false, anno.key());
             } else if (element.isAnnotationPresent(LogOnceFile.class)) {
                 LogOnceFile anno = element.getAnnotation(LogOnceFile.class);
-                return new LogMetadata(LogLevel.DEFAULT, true, anno.path());
+                return new LogMetadata(LogLevel.DEFAULT, true, anno.key());
             } else if (element.isAnnotationPresent(LogOnceNT.class)) {
                 LogOnceNT anno = element.getAnnotation(LogOnceNT.class);
-                return new LogMetadata(LogLevel.DEFAULT, true, anno.path());
+                return new LogMetadata(LogLevel.DEFAULT, true, anno.key());
             } else {
                 return null;
             }


### PR DESCRIPTION
Path is a bit of a confusing name for the "path" parameter since it's not really a path, it's a relative path which can be very confusing (I got it mixed up at first). Key is a name that more accurately describes what it is, which is what key to log the variable under.