### PR TITLE
Add support for logging suppliers in Logged classes

### DIFF
--- a/monologue/src/generate/java/Logged.java.jinja
+++ b/monologue/src/generate/java/Logged.java.jinja
@@ -1,5 +1,8 @@
 package monologue;
 
+
+import java.util.function.*;
+import edu.wpi.first.util.function.FloatSupplier;
 import edu.wpi.first.util.struct.StructSerializable;
 
 public interface Logged {
@@ -8,6 +11,46 @@ public interface Logged {
   }
   public default String getFullPath() {
     return Monologue.loggedRegistry.getOrDefault(this, "notfound");
+  }
+
+  public default void addLoggingSupplier(String key, DoubleSupplier value) {
+    Monologue.ntLogger.addDouble(key,()->value.getAsDouble());
+  }
+
+  public default void addLoggingSupplier(String key, DoubleSupplier value, LogLevel level) {
+    Monologue.ntLogger.addDouble(key,()->value.getAsDouble(), level);
+  }
+
+  public default void addLoggingSupplier(String key, IntSupplier value) {
+    Monologue.ntLogger.addInteger(key,()->value.getAsInt());
+  }
+
+  public default void addLoggingSupplier(String key, IntSupplier value, LogLevel level) {
+    Monologue.ntLogger.addInteger(key,()->value.getAsInt(), level);
+  }
+
+  public default void addLoggingSupplier(String key, BooleanSupplier value) {
+    Monologue.ntLogger.addBoolean(key,()->value.getAsBoolean());
+  }
+
+  public default void addLoggingSupplier(String key, BooleanSupplier value, LogLevel level) {
+    Monologue.ntLogger.addBoolean(key,()->value.getAsBoolean(), level);
+  }
+  
+  public default void addLoggingSupplier(String key, FloatSupplier value) {
+    Monologue.ntLogger.addFloat(key,()->value.getAsFloat());
+  }
+
+  public default void addLoggingSupplier(String key, FloatSupplier value, LogLevel level) {
+    Monologue.ntLogger.addFloat(key,()->value.getAsFloat(), level);
+  }
+
+  public default void addLoggingSupplier(String key, LongSupplier value) {
+    Monologue.ntLogger.addLong(key,()->value.getAsLong());
+  }
+
+  public default void addLoggingSupplier(String key, LongSupplier value, LogLevel level) {
+    Monologue.ntLogger.addLong(key,()->value.getAsLong(), level);
   }
 {%for t in types%}
   public default void log(String key, {{t.java.ValueType}} value) {

--- a/monologue/src/generate/java/Logged.java.jinja
+++ b/monologue/src/generate/java/Logged.java.jinja
@@ -13,44 +13,44 @@ public interface Logged {
     return Monologue.loggedRegistry.getOrDefault(this, "notfound");
   }
 
-  public default void addLoggingSupplier(String key, DoubleSupplier value) {
-    Monologue.ntLogger.addDouble(key,()->value.getAsDouble());
+  public default void addLoggingSupplier(String key, DoubleSupplier valueSupplier) {
+    Monologue.ntLogger.addDouble(key, valueSupplier::getAsDouble);
   }
 
-  public default void addLoggingSupplier(String key, DoubleSupplier value, LogLevel level) {
-    Monologue.ntLogger.addDouble(key,()->value.getAsDouble(), level);
+  public default void addLoggingSupplier(String key, DoubleSupplier valueSupplier, LogLevel level) {
+    Monologue.ntLogger.addDouble(key, valueSupplier::getAsDouble, level);
   }
 
-  public default void addLoggingSupplier(String key, IntSupplier value) {
-    Monologue.ntLogger.addInteger(key,()->value.getAsInt());
+  public default void addLoggingSupplier(String key, IntSupplier valueSupplier) {
+    Monologue.ntLogger.addInteger(key, valueSupplier::getAsInt);
   }
 
-  public default void addLoggingSupplier(String key, IntSupplier value, LogLevel level) {
-    Monologue.ntLogger.addInteger(key,()->value.getAsInt(), level);
+  public default void addLoggingSupplier(String key, IntSupplier valueSupplier, LogLevel level) {
+    Monologue.ntLogger.addInteger(key, valueSupplier::getAsInt, level);
   }
 
-  public default void addLoggingSupplier(String key, BooleanSupplier value) {
-    Monologue.ntLogger.addBoolean(key,()->value.getAsBoolean());
+  public default void addLoggingSupplier(String key, BooleanSupplier valueSupplier value) {
+    Monologue.ntLogger.addBoolean(key, value::getAsBoolean);
   }
 
-  public default void addLoggingSupplier(String key, BooleanSupplier value, LogLevel level) {
-    Monologue.ntLogger.addBoolean(key,()->value.getAsBoolean(), level);
+  public default void addLoggingSupplier(String key, BooleanSupplier valueSupplier, LogLevel level) {
+    Monologue.ntLogger.addBoolean(key, valueSupplier::getAsBoolean, level);
   }
   
-  public default void addLoggingSupplier(String key, FloatSupplier value) {
-    Monologue.ntLogger.addFloat(key,()->value.getAsFloat());
+  public default void addLoggingSupplier(String key, FloatSupplier valueSupplier) {
+    Monologue.ntLogger.addFloat(key, valueSupplier::getAsFloat);
   }
 
-  public default void addLoggingSupplier(String key, FloatSupplier value, LogLevel level) {
-    Monologue.ntLogger.addFloat(key,()->value.getAsFloat(), level);
+  public default void addLoggingSupplier(String key, FloatSupplier valueSupplier, LogLevel level) {
+    Monologue.ntLogger.addFloat(key, valueSupplier::getAsFloat, level);
   }
 
-  public default void addLoggingSupplier(String key, LongSupplier value) {
-    Monologue.ntLogger.addLong(key,()->value.getAsLong());
+  public default void addLoggingSupplier(String key, LongSupplier valueSupplier) {
+    Monologue.ntLogger.addLong(key, valueSupplier::getAsLong);
   }
 
-  public default void addLoggingSupplier(String key, LongSupplier value, LogLevel level) {
-    Monologue.ntLogger.addLong(key,()->value.getAsLong(), level);
+  public default void addLoggingSupplier(String key, LongSupplier valueSupplier, LogLevel level) {
+    Monologue.ntLogger.addLong(key, valueSupplier::getAsLong, level);
   }
 {%for t in types%}
   public default void log(String key, {{t.java.ValueType}} value) {

--- a/test-project/simgui.json
+++ b/test-project/simgui.json
@@ -31,6 +31,12 @@
     },
     "transitory": {
       "Robot": {
+        "Pose2d##v_/Robot/staticPose": {
+          "Translation2d##v_translation": {
+            "open": true
+          },
+          "open": true
+        },
         "SwerveModuleState##v_/Robot/state": {
           "Rotation2d##v_angle": {
             "open": true

--- a/test-project/src/main/java/frc/robot/Robot.java
+++ b/test-project/src/main/java/frc/robot/Robot.java
@@ -38,6 +38,9 @@ public class Robot extends TimedRobot implements Logged {
   @Log(level = DEFAULT) int lowbandwidthSamples = 0;
   @Log(level = OVERRIDE_FILE_ONLY) int compSamples = 0;
 
+  @Log
+  private static Pose2d staticPose = new Pose2d();
+
   ArrayList<Internal> internals = new ArrayList<>(List.of(
     new Internal(""),
     new Internal(""),
@@ -89,6 +92,7 @@ public class Robot extends TimedRobot implements Logged {
 
   @Override
   public void robotPeriodic() {
+    staticPose = new Pose2d(translation2d, new Rotation2d());
     Monologue.setFileOnly(fileOnlyEntry.get());
     Monologue.updateAll();
     field.getRobotObject().setPose(new Pose2d(samples / 100.0, 0, new Rotation2d()));

--- a/test-project/src/main/java/frc/robot/Robot.java
+++ b/test-project/src/main/java/frc/robot/Robot.java
@@ -21,6 +21,7 @@ import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.DriverStation.MatchType;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.Mechanism2d;
+import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import frc.robot.inheritance.Child;
 
 import static monologue.LogLevel.*;
@@ -30,6 +31,7 @@ import java.util.List;
 
 
 public class Robot extends TimedRobot implements Logged {
+  private CommandXboxController controller = new CommandXboxController(0);
   @Log.Once private boolean flippingBool = false;
   private int samples = 0;
   @Log(level = NOT_FILE_ONLY) int debugSamples = 0;
@@ -74,6 +76,9 @@ public class Robot extends TimedRobot implements Logged {
   public Robot() {
     super();
     Monologue.setupMonologue(this, "/Robot", true, false);
+    addLoggingSupplier("boolSup", fileOnlyEntry);
+    addLoggingSupplier("a", controller.a());
+    addLoggingSupplier("leftX", controller::getLeftX);
   }
 
   @Override


### PR DESCRIPTION
This adds the supplier as equivalent to 

```java
@Log
public <type> key() {
   return supplier.getAs<Type>();
}
```
but with no reflection necessary. 